### PR TITLE
TERMAPI-181 Add ability to override a reward/discount

### DIFF
--- a/terminal_api_flows/__init__.py
+++ b/terminal_api_flows/__init__.py
@@ -66,7 +66,7 @@ def ping():
         exit(1)
 
 
-def get_customers(then_cancel=False, skip_signin=False):
+def get_customers(then_cancel=False, skip_signin=False, allow_discount=True):
     if skip_signin:
         json_data = {
             "customer": {
@@ -108,11 +108,16 @@ def get_customers(then_cancel=False, skip_signin=False):
             break
         res, json_data = http_request("customers", "GET")
 
-    # If there is a reward passed in, apply it
+    # If there is a reward passed in, apply it if allow_discount=True
+    # otherwise if allow_discount=False then pick the first unselected
+    # reward or if there are none remove the discount/reward completely
     discount_uids = []
-    selected_discounts = list(filter(lambda d: d.get("selected", False), json_data["customer"]["discounts"]))
-    if len(selected_discounts) > 0:
-        discount_uids = [selected_discounts[0]["uid"]]
+    discounts = list(filter(lambda x: x["selected"]==allow_discount, json_data["customer"]["discounts"]))
+
+    if len(discounts) > 0:
+        # Even if its an override we just grab the first discount id
+        # In a point of sale you can set this to whatever discount ids are available
+        discount_uids = [discounts[0]["uid"]]
 
     print('--------------- Customer Data ---------------')
     print(json_data)

--- a/terminal_api_flows/flows/cash_txn.py
+++ b/terminal_api_flows/flows/cash_txn.py
@@ -9,8 +9,8 @@ from terminal_api_flows.tools.decorators import terminal_ping_decorator_3_attemp
 # ********************** #
 
 @terminal_ping_decorator_3_attempts
-def cash_transaction(total, skip_tip=False, skip_reward_notification=False, skip_signin=False):
-    json_data, discount = get_customers(skip_signin=skip_signin)
+def cash_transaction(total, skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True):
+    json_data, discount = get_customers(skip_signin=skip_signin, allow_discount=allow_discount)
 
     pos_checkout_id, pos_order_id, customer_uid = generate_ids(json_data)
 

--- a/terminal_api_flows/flows/credit_txn.py
+++ b/terminal_api_flows/flows/credit_txn.py
@@ -37,8 +37,8 @@ def handle_switch_to_cash_flow(status):
 # *********************** #
 
 @terminal_ping_decorator_3_attempts
-def credit_to_cash_transaction(total=0, skip_tip=False, skip_reward_notification=False):
-    json_data, discount = get_customers()
+def credit_to_cash_transaction(total=0, skip_tip=False, skip_reward_notification=False, allow_discount=True):
+    json_data, discount = get_customers(allow_discount=allow_discount)
 
     pos_checkout_id, pos_order_id, customer_uid = generate_ids(json_data)
 
@@ -105,8 +105,8 @@ def credit_to_cash_transaction(total=0, skip_tip=False, skip_reward_notification
 
 
 @terminal_ping_decorator_3_attempts
-def credit_transaction(total=0, skip_tip=False, skip_reward_notification=False, skip_signin=False):
-    json_data, discount = get_customers(skip_signin=skip_signin)
+def credit_transaction(total=0, skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True):
+    json_data, discount = get_customers(skip_signin=skip_signin, allow_discount=allow_discount)
 
     pos_checkout_id, pos_order_id, customer_uid = generate_ids(json_data)
 

--- a/terminal_api_flows/flows/other_txn.py
+++ b/terminal_api_flows/flows/other_txn.py
@@ -8,8 +8,8 @@ from terminal_api_flows.tools.decorators import terminal_ping_decorator_3_attemp
 # Other Transaction Flow  #
 # *********************** #
 @terminal_ping_decorator_3_attempts
-def other_transaction(skip_tip=False, skip_reward_notification=False, skip_signin=False):
-    json_data, discount = get_customers(skip_signin=skip_signin)
+def other_transaction(skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True):
+    json_data, discount = get_customers(skip_signin=skip_signin, allow_discount=allow_discount)
 
     pos_checkout_id, pos_order_id, customer_uid = generate_ids(json_data)
 

--- a/terminal_api_flows/terminal-api.py
+++ b/terminal_api_flows/terminal-api.py
@@ -29,21 +29,24 @@ if __name__ == "__main__":
     # TAPI v1.0.0.3 https://app.swaggerhub.com/apis/fs-integrations/Terminal-API/1.0.0.3
     # There are 3 options to skip screens and you can enable/disable some or all
     # SKIP_TIPS - SKIP_REWARD_NOTIFICATION - SKIP_SIGNIN
+    # allow_discount parameter when set to False will override a discount/reward and replace it with the first
+    # unselected one found. If there are no unselected ones it removes the reward/discount. You can of course
+    # override this with any valid discount uid returned from the GET /customers call (look for the discounts field)
 
-    # Cash Transaction
-    # cash_transaction(total=850, skip_tip=False, skip_reward_notification=False, skip_signin=False)
+    # Cash Transaction (Reminder: tips are only on credit transactions so skip_tip has no effect here)
+    # cash_transaction(total=850, skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True)
 
     # $0 Dollar Cash Transaction
-    # cash_transaction(total=0, skip_tip=False, skip_reward_notification=False, skip_signin=False)
+    # cash_transaction(total=0, skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True)
 
     # Credit Transaction
-    # credit_transaction(1550, skip_tip=False, skip_reward_notification=False, skip_signin=False)
+    # credit_transaction(1550, skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True)
 
     # Credit to Cash Transaction
     # Note to partners: cash switching will be triggered if cPay returns any card decline, swipe read errors, etc.
     # Note: you cannot sign in with a credit card to trigger this - sign in with a phone number
     # Note: skip_signin is not available in this kind of flow
-    # credit_to_cash_transaction(1550, skip_tip=False, skip_reward_notification=False)
+    # credit_to_cash_transaction(1550, skip_tip=False, skip_reward_notification=False, allow_discount=True)
 
     # $0 Dollar Credit Transaction
     # Note to partners: If you are running a $0 transaction you should run
@@ -52,7 +55,7 @@ if __name__ == "__main__":
     # credit_transaction(total=0)
 
     # Other Transaction
-    # other_transaction(skip_tip=False, skip_reward_notification=False, skip_signin=False)
+    # other_transaction(skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True)
 
     # Cancel Transaction
     # cancel_transaction()


### PR DESCRIPTION
[TERMAPI-181](https://sumupteam.atlassian.net/browse/TERMAPI-181) adds the ability to override a selected discount/reward. If there are any available discounts besides the selected one then that will be used otherwise it will just remove the discount.

Related: [CPAY-1760](https://sumupteam.atlassian.net/browse/CPAY-1760)

[TERMAPI-181]: https://sumupteam.atlassian.net/browse/TERMAPI-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPAY-1760]: https://sumupteam.atlassian.net/browse/CPAY-1760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ