### PR TITLE
TERMAPI-214 Skip screens in real time

### DIFF
--- a/terminal_api_flows/__init__.py
+++ b/terminal_api_flows/__init__.py
@@ -38,7 +38,7 @@ def http_request(endpoint, action, json_body="") -> (urllib3.HTTPResponse, dict)
         headers={
             "pos-id": f"{POS_ID}",
             "fivestars-software-id": f"{FIVESTARS_SOFTWARE_ID}",
-            "authorization": f"Basic {b64encode(bytes(f'{KEY_SECRET}', encoding='ascii')).decode('ascii')}",
+            "authorization": f"Basic {b64encode(bytes(f'{KEY_SECRET}', encoding='utf-8')).decode('utf-8')}",
             "content-type": "application/json",
             "accept": "application/json",
         },
@@ -54,6 +54,13 @@ def http_request(endpoint, action, json_body="") -> (urllib3.HTTPResponse, dict)
     # Add a sleep if you want to slow the calls down
     # time.sleep(2)
     return request, json.loads(request.data.decode("utf-8"))
+
+
+def skip_screen():
+    print("Skipping current screen")
+    res, json_data = http_request(f"actions", "POST", json.dumps({"action": "pay_skip_user_action"}).encode("utf-8"))
+    print(f"Actions endpoint response: {res.status}")
+    print(f"    `-------------payload: {json_data['status']}")
 
 
 def ping():

--- a/terminal_api_flows/terminal-api.py
+++ b/terminal_api_flows/terminal-api.py
@@ -34,13 +34,37 @@ if __name__ == "__main__":
     # override this with any valid discount uid returned from the GET /customers call (look for the discounts field)
 
     # Cash Transaction (Reminder: tips are only on credit transactions so skip_tip has no effect here)
-    # cash_transaction(total=850, skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True)
+    # cash_transaction(
+    #     total=850,
+    #     skip_tip=False,
+    #     skip_reward_notification=False,
+    #     skip_signin=False,
+    #     allow_discount=True
+    # )
 
     # $0 Dollar Cash Transaction
     # cash_transaction(total=0, skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True)
 
     # Credit Transaction
-    # credit_transaction(1550, skip_tip=False, skip_reward_notification=False, skip_signin=False, allow_discount=True)
+    # credit_transaction(
+    #     1875,
+    #     skip_tip=False,
+    #     # You can skips these screens when you post the checkout
+    #     skip_reward_notification=False,
+    #     skip_signin=False,
+    #     allow_discount=True,
+    #     # You can skips these screens when they show up in real time
+    #     # The notifications can happen very fast so you may not see them
+    #     # prior to re-starting your long poll connection. A second call to
+    #     # the actions endpoint to skip a screen might be required if you suspect
+    #     # you are on a screen you want to skip.
+    #     skip_tips_screen=True,
+    #     # Approval screen happens very fast after the POST checkouts and
+    #     # is very difficult to catch in real time. If you wan to test this you can
+    #     # wait for the 2 minute timeout and it will move you along to the next screen.
+    #     # Note: The approval screen only shows when early checkin with a credit card is used
+    #     skip_approval_screen=False,
+    #     skip_reward_notification_screen=True)
 
     # Credit to Cash Transaction
     # Note to partners: cash switching will be triggered if cPay returns any card decline, swipe read errors, etc.

--- a/terminal_api_flows/terminal-api.py
+++ b/terminal_api_flows/terminal-api.py
@@ -60,9 +60,10 @@ if __name__ == "__main__":
     #     # you are on a screen you want to skip.
     #     skip_tips_screen=True,
     #     # Approval screen happens very fast after the POST checkouts and
-    #     # is very difficult to catch in real time. If you wan to test this you can
+    #     # is very difficult to catch in real time. If you want to test this you can
     #     # wait for the 2 minute timeout and it will move you along to the next screen.
     #     # Note: The approval screen only shows when early checkin with a credit card is used
+    #     # and a card checkout is started.
     #     skip_approval_screen=False,
     #     skip_reward_notification_screen=True)
 


### PR DESCRIPTION
[TERMAPI-214](https://sumupteam.atlassian.net/browse/TERMAPI-214)

- Adds the ability to skip screens based upon feedback from `GET /checkouts/{pos-checkout-id}`
- Uses the new `actions` endpoint to skip screens
- Lots of comments for integrators to read

[TERMAPI-214]: https://sumupteam.atlassian.net/browse/TERMAPI-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ