### PR TITLE
[TERMAPI-245] Remove custom user agent header

### DIFF
--- a/terminal_api_flows/__init__.py
+++ b/terminal_api_flows/__init__.py
@@ -39,7 +39,6 @@ def http_request(endpoint, action, json_body="") -> Tuple[urllib3.HTTPResponse, 
         headers={
             "pos-id": f"{POS_ID}",
             "fivestars-software-id": f"{FIVESTARS_SOFTWARE_ID}",
-            "User-agent": "TapiPythonSampleClient",
             "authorization": f"Basic {b64encode(bytes(f'{KEY_SECRET}', encoding='utf-8')).decode('utf-8')}",
             "content-type": "application/json",
             "accept": "application/json",


### PR DESCRIPTION
[TERMAPI-245](https://sumupteam.atlassian.net/browse/TERMAPI-245)

Remove custom user agent header.

`User-Agent` header used to be on a famous list of forbidden headers, which means that they cannot be modified programmatically in order to prevent security vulnerabilities or conflicts. When the `User-Agent` header was removed from the list of forbidden headers, the paths diverged: Chromium-based browsers still thinks it is an unsafe header, while Firefox (as an example) has no problems with it.

Because this difference may cause errors and would not let us use properly our custom `User-Agent` header, it has been decided to remove it.

[TERMAPI-245]: https://sumupteam.atlassian.net/browse/TERMAPI-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ